### PR TITLE
avoid --with-Nth because it's so slow

### DIFF
--- a/autoload/vache.vim
+++ b/autoload/vache.vim
@@ -40,6 +40,7 @@ function! vache#lookup(...)
     let l:filetype_options = extend(s:filetype_options, g:vache_filetype_options)
 
     let l:get_docsets_cmd = join([ s:get_docsets_cmd, g:vache_default_docset_dir ])
+    let l:docset_root = g:vache_default_docset_dir
     if has_key(l:filetype_options, &ft)
         let l:options = filetype_options[&ft]
         if type(l:options) == 3
@@ -48,6 +49,7 @@ function! vache#lookup(...)
             let l:get_docsets_cmd = join([ s:get_docsets_cmd ] + l:args)
 
         elseif type(l:options) == 4
+            let l:docset_root = l:options.dir
             let l:get_docsets_cmd = join([ s:get_docsets_cmd, l:options.dir ])
 
         else
@@ -55,7 +57,7 @@ function! vache#lookup(...)
         endif
     endif
 
-    let l:fzf_options = '--with-nth=2,3 --delimiter="\t"'
+    let l:fzf_options = ''
     if a:0 == 1
         let l:fzf_options = l:fzf_options . ' --query="' . a:1 . '"'
     endif
@@ -63,7 +65,8 @@ function! vache#lookup(...)
     call fzf#run({
         \ 'source': l:get_docsets_cmd,
         \ 'sink': function('vache#browse#browse'),
-        \ 'options': l:fzf_options
+        \ 'options': l:fzf_options,
+        \ 'docset_root': l:docset_root,
         \ })
 endfunction
 
@@ -79,6 +82,6 @@ function! vache#sift(...)
     call fzf#run({
         \ 'source': join([ l:get_docsets_cmd, g:vache_default_docset_dir ]),
         \ 'sink': function('vache#browse#browse'),
-        \ 'options': '--with-nth=2,3 --delimiter="\t"',
+        \ 'docset_root': g:vache_default_docset_dir,
         \ })
 endfunction

--- a/autoload/vache/browse.vim
+++ b/autoload/vache/browse.vim
@@ -26,9 +26,8 @@ if has('unix')
     endif
 endif
 
-function! vache#browse#browse(line)
-    let l:uri = pyeval('vache.decode_url(unicode(vim.eval("a:line").strip()))')
-
+function! vache#browse#browse(line) dict
+    let l:uri = pyeval('vache.construct_url(vim.eval("self.docset_root"), unicode(vim.eval("a:line").strip()))')
     let l:browser_out = system(s:browse_cmd(l:uri))
     if v:shell_error != 0
         echoerr 'vache: browser err: ' . l:browser_out

--- a/autoload/vache/db.py
+++ b/autoload/vache/db.py
@@ -63,10 +63,11 @@ def get_uri_path(doc_db, name):
             return uri
 
         except sqlite3.OperationalError:
-            (uri,) = conn.execute('''select ZPATH from ZFILEPATH
+            (uri,) = conn.execute(
+                '''select ZPATH from ZFILEPATH
                 where Z_PK = (select ZFILE from ZTOKENMETAINFORMATION
-                    where Z_PK = (select ZMETAINFORMATION from ZTOKEN
-                        where ZTOKENNAME = ?))''',
+                where Z_PK = (select ZMETAINFORMATION from ZTOKEN
+                where ZTOKENNAME = ?))''',
                 (name,)
             ).fetchone()
             return uri

--- a/autoload/vache/vache.py
+++ b/autoload/vache/vache.py
@@ -37,7 +37,7 @@ def get_names(plists):
 
 def construct_url(doc_root, line):
     family, name = string.split(line, SEP)
-    for _, path in get_plist_files_for_families(doc_root, [ family ]):
+    for _, path in get_plist_files_for_families(doc_root, [family]):
         doc_db = doc_db_for(path)
         try:
             uri_path = db.get_uri_path(doc_db, name)


### PR DESCRIPTION
here we avoid the price paid for packing the plist path through fzf and using --with-nth to hide them from the user. the cost we pay is slightly more complicated code in vimscript land for our vache#browse#browse function which now needs to be aware of the docset root used for the initial documentation target lookup, as well as  more work being done in vache.construct_url which now has to guess which sqlite database houses the identifier

fixes #14 